### PR TITLE
Fix keyboard interrupt handling

### DIFF
--- a/testnet-ripe-anchors.py
+++ b/testnet-ripe-anchors.py
@@ -294,4 +294,7 @@ def main():
             sys.exit(1)
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/testnet-ripe-anchors.py
+++ b/testnet-ripe-anchors.py
@@ -185,9 +185,14 @@ class Tester(object):
             self._limiter.release()
 
     def run_tests(self, targets):
-        for target in targets:
-            self._run_test(target)
-        self._flush_work()
+        def _run():
+            for target in targets:
+                self._run_test(target)
+            self._flush_work()
+        t = threading.Thread(target=_run)
+        t.start()
+        while t.is_alive():
+            t.join(timeout=1000) # We need to specify a timeout here to make it interruptible by Ctrl+C
 
     @property
     def results(self):

--- a/testnet-ripe-anchors.py
+++ b/testnet-ripe-anchors.py
@@ -187,10 +187,10 @@ class Tester(object):
     def run_tests(self, targets):
         for target in targets:
             self._run_test(target)
+        self._flush_work()
 
     @property
     def results(self):
-        self._flush_work()
         with self._results_lock:
             ret = copy.deepcopy(self._results)
         return ret

--- a/testnet-ripe-anchors.py
+++ b/testnet-ripe-anchors.py
@@ -166,7 +166,7 @@ class Tester(object):
         except:
             return False
 
-    def run_test(self, address):
+    def _run_test(self, address):
 
         def _test_function():
             result = Tester._test_address(address)
@@ -183,6 +183,10 @@ class Tester(object):
             self._limiter.acquire()
         for i in range(0, Tester._MAX_THREADS):
             self._limiter.release()
+
+    def run_tests(self, targets):
+        for target in targets:
+            self._run_test(target)
 
     @property
     def results(self):
@@ -259,8 +263,7 @@ def main():
     targets = random.sample(targets, count)
 
     tester = Tester()
-    for target in targets:
-        tester.run_test(target)
+    tester.run_tests(targets)
 
     results = tester.results
     total = len(results)

--- a/testnet-ripe-anchors.py
+++ b/testnet-ripe-anchors.py
@@ -176,6 +176,7 @@ class Tester(object):
 
         self._limiter.acquire()
         t = threading.Thread(target=_test_function)
+        t.daemon = True
         t.start()
 
     def _flush_work(self):
@@ -190,6 +191,7 @@ class Tester(object):
                 self._run_test(target)
             self._flush_work()
         t = threading.Thread(target=_run)
+        t.daemon = True
         t.start()
         while t.is_alive():
             t.join(timeout=1000) # We need to specify a timeout here to make it interruptible by Ctrl+C


### PR DESCRIPTION
Allow the process to be interrupted when pressing Ctrl+C.
